### PR TITLE
TINF-57: Frontend Deployment an neue Struktur anpassen

### DIFF
--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -3,7 +3,7 @@ name: Development
 on:
   push:
     branches:
-      - master
+      - develop
 
 jobs:
   build:

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,0 +1,66 @@
+name: integration
+
+on:
+  push:
+    branches:
+      - 'release/**'
+
+jobs:
+  build:
+    name: Build+Push image
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Login to registry
+        if: success()
+        uses: actions-hub/docker/login@master
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build image
+        if: success()
+        run: docker build --build-arg VERSION=int-${GITHUB_REF##*/} --build-arg COMMIT=${GITHUB_SHA} -t sakpaas/frontend:int-${GITHUB_REF##*/} .
+
+      - name: Tag image
+        if: success()
+        run: docker tag sakpaas/frontend:int-${GITHUB_REF##*/} sakpaas/frontend:integration
+
+      - name: Push <image>:integration
+        if: success()
+        uses: actions-hub/docker@master
+        with:
+          args: push sakpaas/frontend:int-${GITHUB_REF##*/}
+
+      - name: Push <image>:integration
+        if: success()
+        uses: actions-hub/docker@master
+        with:
+          args: push sakpaas/frontend:integration
+
+
+  deploy:
+    name: Deployment
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          repository: 'SAKPaaS/deployment'
+
+      - name: Kustomize
+        uses: stefanprodan/kube-tools@v1
+        with:
+          kustomize: 3.4.0
+          command: "cd frontend/integration && kustomize edit set image sakpaas/frontend=sakpaas/frontend:int-${GITHUB_REF##*/}"
+
+      - name: Deploy
+        uses: actions-hub/kubectl@master
+        env:
+          KUBE_CONFIG: ${{ secrets.KUBE_CONFIG }}
+        with:
+          args: apply -k frontend/integration


### PR DESCRIPTION
Damit das automatische Deployment wieder funktioniert, würde ich das Deployment für die `development` und die `production` Umgebung wiederherstellen ohne eine Integrationsumgebung einzuführen, da diese auch unabhängig eingeführt werden kann, da hier noch ein paar Fragen zu klären sind.